### PR TITLE
Mulighed for at sende parametre "timeout" og "error" til jQuery.ajax().

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Det er muligt at angive følgende options:
  - <strong>minLength</strong>: Antal karakterer, der skal være tastet for autocomplete vises (default 2)
  - <strong>params</strong>: Angiver yderligere parametre (eksempelvis postnr, kommunekode), som sendes med ved kald til DAWA
  - <strong>adgangsadresserOnly</strong>: Angiver, at der indtastes en adgangsadresse og ikke en fuld adresse (default: false)
+ - <strong>timeout</strong>: Parameter til jQuery.ajax(): Antal millisekunder der ventes på svar fra serveren før der gives op (default: null)
+ - <strong>error</strong>: Parameter til jQuery.ajax(): Callback-funktion ved fejl eller timeout. (default: null).
 
 ## Events
 DAWA Autocomplete udsender følgende events:

--- a/dawa-autocomplete.js
+++ b/dawa-autocomplete.js
@@ -6,6 +6,8 @@ $.widget( "dawa.dawaautocomplete", {
     delay: 0,
     adgangsadresserOnly: false,
     autoFocus: true,
+    timeout: null,
+    error: null,
     params: {}
   },
 
@@ -25,12 +27,14 @@ $.widget( "dawa.dawaautocomplete", {
         url: options.baseUrl + path,
         dataType: options.jsonp ? "jsonp" : "json",
         data: $.extend({}, params, options.params),
+        timeout: options.timeout,
         success: function(data) {
           if(cache) {
             cache[ stringifiedParams] = data;
           }
           cb(data);
-        }
+        },
+        error: options.error
       });
     }
 


### PR DESCRIPTION
Hej.
Vi bruger det til at droppe autocomplete-muligheden og gå tilbage til en traditionel adresse-indtastning efter et timeout - så vore kunder også kan handle hvis servicen er nede.

``` php
$input
    .dawaautocomplete({
        timeout: 2000,
        select: function(event, address) {
            // Here we handle selection
        },
        error: function(jqXHR, textStatus, errorThrown) {
            // DAWA failed, so fallback to regular fields.
        }
    })
```

I øvrigt tak for en fed service!
