### PR TITLE
 Use https protocol as default value for `baseUrl` 

### DIFF
--- a/dawa-autocomplete.js
+++ b/dawa-autocomplete.js
@@ -1,7 +1,7 @@
 $.widget("dawa.dawaautocomplete", {
 	options: {
 		jsonp: !("withCredentials" in (new XMLHttpRequest())),
-		baseUrl: 'http://dawa.aws.dk',
+		baseUrl: 'https://dawa.aws.dk',
 		minLength: 2,
 		delay: 0,
 		adgangsadresserOnly: false,


### PR DESCRIPTION
Make sure that when deployed on https sites, dawa-autocomplete still works with
the default `baseUrl` intact.

Since https sites can't communicate with http services, but http sites can
communicate with https services, change the default `baseUrl` protocol to
https.