### PR TITLE
Add support for autocomplete calls

### DIFF
--- a/dawa-autocomplete.js
+++ b/dawa-autocomplete.js
@@ -158,7 +158,7 @@ $.widget("dawa.dawaautocomplete", {
 		});
 		element.autocomplete(autocompleteOptions).data("ui-autocomplete")._renderItem = function (ul, item) {
 			return $("<li></li>")
-				.append(item.forslagstekst)
+				.append(item.forslagstekst || item.tekst)
 				.appendTo(ul);
 		};
 		element.on("autocompletefocus", function (event) {


### PR DESCRIPTION
This commit adds support for all the autocomplete calls listed in http://dawa.aws.dk/listerdok (except Supplerende bynavn, since it doesn't contain the 'tekst' object variable) by utilizing that they all contain the `item.tekst` object variable.

It isn't the nicest fix. 
Eg. in https://github.com/greew/autocomplete/blob/master/dawa-autocomplete.js#L142 
This check is unnecessary when not working with the standard autocomplete URL, but it doesn't hurt either.

Let me know if I should continue working on it or if it's ready for merging.
